### PR TITLE
Added support for unbound repetitions, updated tests

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -36,16 +36,20 @@ func Parse(expression string) (*IntervalDescriptor, error) {
 				return nil, errors.New("repetitions component must be at the beginning of the string")
 			}
 
-			r, err := strconv.Atoi(v[1:])
+			if len(v) == 1 && i == 0 {
+				ret.Repeats = -1
+			} else {
+				r, err := strconv.Atoi(v[1:])
 
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse repetitions, %s", err.Error())
-			}
+				if  err != nil {
+					return nil, fmt.Errorf("unable to parse repetitions, %s", err.Error())
+				}
 
-			if r <= 0 {
-				return nil, errors.New("repeat value must be greater than zero")
+				if r <= 0 {
+					return nil, errors.New("repeat value must be greater than zero")
+				}
+				ret.Repeats = r
 			}
-			ret.Repeats = r
 			repeatsSet = true
 			continue
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -47,6 +47,11 @@ func TestParseZeroRepetitions(t *testing.T) {
 	assert.Equal(t, "repeat value must be greater than zero", err.Error())
 }
 
+func TestParseUnboundRepetitions(t *testing.T) {
+	result, _ := Parse("R/2008-03-01T13:00:00Z")
+	assert.Equal(t, -1, result.Repeats)
+}
+
 func TestParseMultiplePeriods(t *testing.T) {
 	result, err := Parse("R1/2008-03-01T13:00:00Z/P1Y2M10DT2H30M/P1Y2M10DT2H30M")
 	assert.Nil(t, result)


### PR DESCRIPTION
According with the ISO8601, it's possible to have an infinite number of repetitions:

> Repeating intervals are specified in clause "4.5 Recurring time interval". They are formed by adding "R[n]/" to the beginning of an interval expression, where R is used as the letter itself and [n] is replaced by the number of repetitions. Leaving out the value for [n] means an unbounded number of repetitions. 
[https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)

I'm not sure if -1 is the correct way to represent it in Repeats, but that was what I used in a project where I needed to have an unbound number of repeats, e.g. `R/2019-01-01T00:00:00Z/P1D` to describe something to be repeated daily starting 2019/01/01 00:00, which would result in the following:

```json 
        "schedule": {
            "start": "2019-01-01T00:00:00Z",
            "end": "0001-01-01T00:00:00Z",
            "repeats": -1,
            "period": {
                "years": 0,
                "months": 0,
                "weeks": 0,
                "days": 1,
                "hours": 0,
                "minutes": 0,
                "seconds": 0
            }
```